### PR TITLE
Removing tls transport in extension data test

### DIFF
--- a/src/main/scripts/org/reaktivity/specification/nukleus/tls/streams/connection.established.with.extension.data/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tls/streams/connection.established.with.extension.data/client.rpt
@@ -20,7 +20,7 @@ connect await ROUTED_CLIENT
         "nukleus://tls/streams/source"
   option nukleus:route ${newClientAcceptRef}
   option nukleus:window 65536
-  option nukleus:transmission "duplex"
+  option nukleus:transmission "half-duplex"
 
 write nukleus:begin.ext "extension"
 

--- a/src/main/scripts/org/reaktivity/specification/nukleus/tls/streams/connection.established.with.extension.data/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/nukleus/tls/streams/connection.established.with.extension.data/server.rpt
@@ -21,7 +21,7 @@ property clientAccept "nukleus://tls/streams/source"
 accept ${clientAccept}
   option nukleus:route  ${newClientAcceptRef}
   option nukleus:window 65536
-  option nukleus:transmission "duplex"
+  option nukleus:transmission "half-duplex"
 accepted
 
 read nukleus:begin.ext "extension"

--- a/src/main/scripts/org/reaktivity/specification/tls/connection.established.with.extension.data/client.rpt
+++ b/src/main/scripts/org/reaktivity/specification/tls/connection.established.with.extension.data/client.rpt
@@ -17,14 +17,10 @@
 property newServerAcceptRef  ${nukleus:newRouteRef()} # external
 
 connect await ROUTED_SERVER
-        "tls://localhost:9090"
-  option tls:transport "nukleus://tls/streams/source"
-  option tls:trustStoreFile "src/test/democa/cacerts"
-  option tls:trustStorePassword "generated"
-  option tls:applicationProtocols "protocol1,protocol2"
+        "nukleus://target/streams/tls"
   option nukleus:route ${newServerAcceptRef}
   option nukleus:window 65536
-  option nukleus:transmission "duplex"
+  option nukleus:transmission "half-duplex"
 
 write nukleus:begin.ext "extension"
 

--- a/src/main/scripts/org/reaktivity/specification/tls/connection.established.with.extension.data/server.rpt
+++ b/src/main/scripts/org/reaktivity/specification/tls/connection.established.with.extension.data/server.rpt
@@ -16,16 +16,10 @@
 
 property newServerAcceptRef  ${nukleus:newRouteRef()} # external
 
-property serverAccept "nukleus://tls/streams/source"
-
-accept "tls://localhost:9090"
-  option tls:transport ${serverAccept}
-  option tls:keyStoreFile "src/test/democa/localhost"
-  option tls:keyStorePassword "generated"
-  option tls:applicationProtocols "protocol2"
+accept "nukleus://target/streams/tls"
   option nukleus:route  ${newServerAcceptRef}
   option nukleus:window 65536
-  option nukleus:transmission "duplex"
+  option nukleus:transmission "half-duplex"
 accepted
 
 read nukleus:begin.ext "extension"


### PR DESCRIPTION
Tests whether the BEGIN extension data is passed on to the target nukleus.
It doesn't require any tls handshake, so removing tls transport